### PR TITLE
Update CombineAutopilotHashes.ps1

### DIFF
--- a/CombineAutopilotHashes.ps1
+++ b/CombineAutopilotHashes.ps1
@@ -70,7 +70,7 @@ ElseIf( (Test-Path "$ScriptPath\CombinedHashes.csv" -ErrorAction SilentlyContinu
 ##* MAIN LOGIC
 ##*========================================================================
 $OutfileParams = @{
-    Encoding=[System.Text.Encoding]::ASCII
+    Encoding='ascii'
     Append=$Append
     Force=$(!$Append)
 }


### PR DESCRIPTION
Does not work on PS 5.1.19041.4780
Cannot validate argument on parameter 'Encoding'. The argument "System.Text.ASCIIEncoding" does not belong to the set "unknown,string,unicode,bigendianunicode,utf8,utf7,utf32,ascii,default,oem" specified by the ValidateSet